### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "version": "1.0.0",
     "require": {
         "league/commonmark": "^0.17.0",
-        "illuminate/view": "^5.6"
+        "illuminate/view": "5.6.*"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Laravel doesn't follow semver. So having `^5.x`, `5.*` or `>=5.x` will mean that composer will install a future version even though that version breaks the package.